### PR TITLE
Make a centralized load_ron_asset fn

### DIFF
--- a/src/components/arena.rs
+++ b/src/components/arena.rs
@@ -1,12 +1,11 @@
 use amethyst::ecs::prelude::{Component, DenseVecStorage, World};
 
-use ron::de::from_reader;
 use serde::Deserialize;
-use std::{collections::HashMap, fs::File};
+use std::collections::HashMap;
 
 use crate::resources::{GameModes};
 use crate::components::{WeaponNames, Hitbox, HitboxShape};
-
+use crate::load_ron_asset;
 
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize)]
@@ -172,8 +171,6 @@ pub struct ArenaProperties {
 }
 
 
-
-
 #[derive(Clone)]
 pub struct ArenaStoreResource {
     pub properties: HashMap<ArenaNames, ArenaProperties>,
@@ -181,33 +178,11 @@ pub struct ArenaStoreResource {
 }
 
 
-/* Release rally.exe (crashes):
-"\\\\?\\C:\\Users\\Mike\\rust\\amethyst\\rally_game\\target\\release\\assets/game/vehicles.ron"
-
-cargo run
-"C:\\Users\\Mike\\rust\\amethyst\\rally_game\\assets/game/vehicles.ron"
-*/
-
 pub fn build_arena_store(world: &mut World) {
-    // let app_root = current_dir();
-    // let input_path = app_root.unwrap().join("assets/game/vehicles.ron");
-
-    let input_path_properties = format!("{}/assets/game/arena_properties.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_path_modes = format!("{}/assets/game/arena_game_modes.ron", env!("CARGO_MANIFEST_DIR"));
-    
-    let f_properties = File::open(&input_path_properties).expect("Failed opening file");
-    let f_modes = File::open(&input_path_modes).expect("Failed opening file");
-
-    let arena_properties_map: HashMap<ArenaNames, ArenaProperties> =
-        from_reader(f_properties).expect("Failed to load config");
-    let arena_game_modes_map: HashMap<GameModes, Vec<ArenaNames>> =
-        from_reader(f_modes).expect("Failed to load config");
-
-    let arena_store = ArenaStoreResource {
-        properties: arena_properties_map,
-        game_modes: arena_game_modes_map,
-    };
-    world.insert(arena_store.clone());
+    world.insert(ArenaStoreResource {
+        properties: load_ron_asset(&["game", "arena_properties.ron"]),
+        game_modes: load_ron_asset(&["game", "arena_game_modes.ron"]),
+    });
 }
 
 

--- a/src/components/vehicles.rs
+++ b/src/components/vehicles.rs
@@ -1,15 +1,12 @@
 use amethyst::{
     core::Transform,
     ecs::prelude::{Component, DenseVecStorage, Entity, World},
-    //utils::{application_root_dir},
 };
 
 use rand::Rng;
 use std::f32::consts::PI;
-use ron::de::from_reader;
 use serde::Deserialize;
-use std::{collections::HashMap, fs::File};
-//use std::env::current_dir;
+use std::collections::HashMap;
 
 use crate::components::{
     Armor, Health, Player, Repair, Shield, DurationDamage, 
@@ -17,7 +14,7 @@ use crate::components::{
 };
 use crate::resources::GameModes;
 use crate::entities::ui::PlayerStatusText;
-
+use crate::load_ron_asset;
 
 
 //VehicleNames correspond to the vehicle_properties.ron
@@ -459,36 +456,11 @@ pub struct VehicleStoreResource {
 }
 
 
-/* Release rally.exe (crashes):
-"\\\\?\\C:\\Users\\Mike\\rust\\amethyst\\rally_game\\target\\release\\assets/game/vehicles.ron"
-
-cargo run
-"C:\\Users\\Mike\\rust\\amethyst\\rally_game\\assets/game/vehicles.ron"
-*/
-
 pub fn build_vehicle_store(world: &mut World) -> VehicleStoreResource {
-    // let app_root = current_dir();
-    // let input_path = app_root.unwrap().join("assets/game/vehicles.ron");
-
-    let input_path_properties = format!("{}/assets/game/vehicle_properties.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_path_order = format!("{}/assets/game/vehicle_selection_order.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_type_sprites = format!("{}/assets/game/vehicle_type_sprites.ron", env!("CARGO_MANIFEST_DIR"));
-    
-    let f_properties = File::open(&input_path_properties).expect("Failed opening file");
-    let f_order = File::open(&input_path_order).expect("Failed opening file");
-    let f_type_sprites = File::open(&input_type_sprites).expect("Failed opening file");
-
-    let vehicle_properties_map: HashMap<VehicleNames, VehicleStats> =
-        from_reader(f_properties).expect("Failed to load config");
-    let vehicle_order_list: Vec<VehicleNames> =
-        from_reader(f_order).expect("Failed to load config");
-    let vehicle_type_sprites: HashMap<VehicleTypes, (usize, usize, usize)> =
-        from_reader(f_type_sprites).expect("Failed to load config");
-
     let vehicle_store = VehicleStoreResource {
-        properties: vehicle_properties_map,
-        order: vehicle_order_list,
-        type_sprites: vehicle_type_sprites,
+        properties: load_ron_asset(&["game", "vehicle_properties.ron"]),
+        order: load_ron_asset(&["game", "vehicle_selection_order.ron"]),
+        type_sprites: load_ron_asset(&["game", "vehicle_type_sprites.ron"]),
     };
     world.insert(vehicle_store.clone());
 

--- a/src/components/weapons.rs
+++ b/src/components/weapons.rs
@@ -1,18 +1,17 @@
 use amethyst::{
     ecs::prelude::{Component, DenseVecStorage, Entities, Entity, LazyUpdate, ReadExpect, World},
     renderer::{palette::Srgba, resources::Tint, SpriteRender, Transparent},
-    utils::{removal::Removal}, //application_root_dir},
+    utils::{removal::Removal},
     ui::{UiTransform, UiImage, Anchor},
 };
 
 use rand::Rng;
-use ron::de::from_reader;
 use serde::Deserialize;
-use std::{collections::HashMap, fs::File};
-//use std::env::current_dir;
+use std::collections::HashMap;
 
 use log::{info};
 
+use crate::load_ron_asset;
 use crate::components::{PlayerWeaponIcon,};
 use crate::resources::{WeaponFireResource, GameWeaponSetup, GameWeaponSelectionMode,};
 
@@ -277,38 +276,13 @@ pub struct WeaponStoreResource {
 }
 
 pub fn build_weapon_store(world: &mut World) {
-    // let app_root = current_dir();
-    // let input_path = app_root.unwrap().join("assets/game/weapons.ron");
-
-    let input_path_weapon_props = format!("{}/assets/game/weapon_properties.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_path_spawn_chance = format!("{}/assets/game/weapon_spawn_chance.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_path_gun_game_order = format!("{}/assets/game/weapon_gun_game_order.ron", env!("CARGO_MANIFEST_DIR"));
-    let input_path_selection_order = format!("{}/assets/game/weapon_selection_order.ron", env!("CARGO_MANIFEST_DIR"));
-
-    let f_weapon_props = File::open(&input_path_weapon_props).expect("Failed opening file");
-    let f_spawn_chance = File::open(&input_path_spawn_chance).expect("Failed opening file");
-    let f_gun_game_order = File::open(&input_path_gun_game_order).expect("Failed opening file");
-    let f_selection_order = File::open(&input_path_selection_order).expect("Failed opening file");
-
-    let weapon_properties_map: HashMap<WeaponNames, WeaponStats> =
-        from_reader(f_weapon_props).expect("Failed to load config");
-    let weapon_spawn_chance_map: HashMap<WeaponNames, u32> =
-        from_reader(f_spawn_chance).expect("Failed to load config");
-    let gun_game_order_map: Vec<WeaponNames> =
-        from_reader(f_gun_game_order).expect("Failed to load config");
-    let selection_order_map: Vec<WeaponNames> =
-        from_reader(f_selection_order).expect("Failed to load config");
-
-
-    let weapon_store = WeaponStoreResource {
-        properties: weapon_properties_map,
-        spawn_chance: weapon_spawn_chance_map,
-        gun_game_order: gun_game_order_map.clone(),
-        gun_game_random_order: gun_game_order_map,
-        selection_order: selection_order_map,
-    };
-
-    world.insert(weapon_store.clone());
+    world.insert(WeaponStoreResource {
+        properties: load_ron_asset(&["game", "weapon_properties.ron"]),
+        spawn_chance: load_ron_asset(&["game", "weapon_spawn_chance.ron"]),
+        gun_game_order: load_ron_asset(&["game", "weapon_gun_game_order.ron"]),
+        gun_game_random_order: load_ron_asset(&["game", "weapon_gun_game_order.ron"]),
+        selection_order: load_ron_asset(&["game", "weapon_selection_order.ron"]),
+    });
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,10 @@ use amethyst::{
         RenderingBundle,
     },
     ui::{RenderUi, UiBundle},
-    utils::{application_root_dir, fps_counter::FpsCounterBundle},
+    utils::{application_dir, application_root_dir, fps_counter::FpsCounterBundle},
 };
+use std::fs::File;
+use std::path::PathBuf;
 
 mod credits;
 mod menu;
@@ -31,6 +33,17 @@ mod systems;
 
 
 use crate::welcome::WelcomeScreen;
+use serde::de::DeserializeOwned;
+
+fn load_ron_asset<T: DeserializeOwned>(path: &[&str]) -> T {
+    let mut path_buf = PathBuf::from("assets");
+    path_buf.extend(path);
+    let path = application_dir(path_buf).expect("Failed to find application directory");
+
+    let file = File::open(&path).expect(&format!("Failed to open file: {:?}", path));
+
+    ron::de::from_reader(file).expect("Failed to load config")
+}
 
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());


### PR DESCRIPTION
Now we'll only have to debug asset loading issues in one place. The new
function uses PathBuf instead of string formatting so it may work better
on Windows.

Related to #23